### PR TITLE
Fix release_13x CI dockerfile

### DIFF
--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -35,12 +35,12 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -f -y llvm-11 clang-11
 
 # Install the tools for release_13x
-RUN apt install -y build-essential manpages-dev \
+RUN apt-get install -y build-essential manpages-dev \
     libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev libncurses5-dev \
     libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt install -y gcc-11 g++-11 python python3-distutils
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get install -y gcc-11 g++-11 python python3-distutils
 
 RUN cd /opt && \
     wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.sh && \


### PR DESCRIPTION
Change to use "apt-get" instead, seems root has issues to
understand "apt". Add -y to force to update without
user intervention